### PR TITLE
[feat] #112 회원정보 입력페이지 이미지추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-range": "^1.8.14",
         "react-router-dom": "^6.20.0",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "sockjs-client": "^1.6.1",
         "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss": "3.3.5",
@@ -5803,6 +5804,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-range": "^1.8.14",
     "react-router-dom": "^6.20.0",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "sockjs-client": "^1.6.1",
     "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "3.3.5",

--- a/src/app/_components/common/Accordion.tsx
+++ b/src/app/_components/common/Accordion.tsx
@@ -13,6 +13,8 @@ const Accordion = ({
   onOpen,
   isOpen,
 }: AccordionProps) => {
+  const getSortedDepartmentList = () =>
+    [...MY_DEPARTMENT_PAGE.DEPARTMENT_LIST].sort()
   const handleSelect = (department: string) => {
     onDepartmentSelect(department)
   }
@@ -51,7 +53,7 @@ const Accordion = ({
 
       {isOpen && (
         <div className="absolute bottom-[230px] left-0 w-[312px] max-h-48 rounded-[16px] overflow-y-scroll scrollbar-hide bg-onepink">
-          {MY_DEPARTMENT_PAGE.DEPARTMENT_LIST.map((department) => (
+          {getSortedDepartmentList().map((department) => (
             <button
               key={department}
               className={`w-full h-12 ${

--- a/src/app/_components/common/SelectedButton.tsx
+++ b/src/app/_components/common/SelectedButton.tsx
@@ -10,6 +10,7 @@ interface SelectedButtonProps {
   imgSrc?: string
   imgSizeW?: number
   imgSizeH?: number
+  imgClassName?: string
 }
 
 const SelectedButton = ({
@@ -21,6 +22,7 @@ const SelectedButton = ({
   imgSrc,
   imgSizeW,
   imgSizeH,
+  imgClassName,
 }: SelectedButtonProps) => {
   const buttonStyles = BUTTON_STYLE[buttonType](className)
   const textLines = buttonText.split('\n')
@@ -33,13 +35,15 @@ const SelectedButton = ({
       disabled={!isActive}
     >
       {imgSrc && (
-        <div className="flex justify-center items-center mb-1">
+        <div
+          className={`${imgClassName} flex justify-center items-center mb-2`}
+        >
           <Image src={imgSrc} alt="" width={imgSizeW} height={imgSizeH} />
         </div>
       )}
       {textLines.map((text, index) => (
         // eslint-disable-next-line react/jsx-key
-        <div>
+        <div className="leading-none">
           {index > 0 && <br />}
           {text}
         </div>

--- a/src/app/_components/common/SelectedButton.tsx
+++ b/src/app/_components/common/SelectedButton.tsx
@@ -8,7 +8,8 @@ interface SelectedButtonProps {
   className: string
   onClick: () => void
   imgSrc?: string
-  imgSize?: string
+  imgSizeW?: number
+  imgSizeH?: number
 }
 
 const SelectedButton = ({
@@ -18,10 +19,12 @@ const SelectedButton = ({
   className,
   onClick,
   imgSrc,
-  imgSize,
+  imgSizeW,
+  imgSizeH,
 }: SelectedButtonProps) => {
   const buttonStyles = BUTTON_STYLE[buttonType](className)
   const textLines = buttonText.split('\n')
+
   return (
     <button
       type="button"
@@ -29,7 +32,11 @@ const SelectedButton = ({
       onClick={onClick}
       disabled={!isActive}
     >
-      {imgSrc && <Image src={imgSrc} alt="" className={imgSize} />}
+      {imgSrc && (
+        <div className="flex justify-center items-center mb-1">
+          <Image src={imgSrc} alt="" width={imgSizeW} height={imgSizeH} />
+        </div>
+      )}
       {textLines.map((text, index) => (
         // eslint-disable-next-line react/jsx-key
         <div>

--- a/src/app/_components/common/userinfo/UserGender.tsx
+++ b/src/app/_components/common/userinfo/UserGender.tsx
@@ -74,7 +74,10 @@ export default function UserGender({ pageNum }: UserGenderProps) {
           buttonType="GENDER"
           isActive
           onClick={handleMaleButtonClick}
-          className={`mr-[7px] bg-zeropink text-primary font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          imgSrc="/illustration/common/gender/male.png"
+          imgSizeW={106}
+          imgSizeH={110}
+          className={`mr-[7px] bg-zeropink text-primary font-sans text-[14px] font-bold justify-end items-center gap-[10px] rounded-3xl ${
             maleButtonSelected ? 'border-[1px] border-primary' : ''
           }`}
         />
@@ -83,7 +86,10 @@ export default function UserGender({ pageNum }: UserGenderProps) {
           buttonType="GENDER"
           isActive
           onClick={handleFemaleButtonClick}
-          className={`ml-[7px] bg-zeropink text-primary font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          imgSrc="/illustration/common/gender/female.png"
+          imgSizeW={106}
+          imgSizeH={110}
+          className={`ml-[7px] bg-zeropink text-primary font-sans text-[14px] font-bold justify-end items-center gap-[10px] rounded-3xl ${
             femaleButtonSelected ? 'border-[1px] border-primary' : ''
           }`}
         />

--- a/src/app/_components/common/userinfo/UserMood.tsx
+++ b/src/app/_components/common/userinfo/UserMood.tsx
@@ -131,7 +131,10 @@ export default function UserMood() {
           buttonType="MOOD"
           isActive
           onClick={handleActButtonClick}
-          className={`mx-2 my-2 font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          imgSrc="/illustration/common/datemood/active.png"
+          imgSizeW={75}
+          imgSizeH={85}
+          className={`mx-2 my-2 font-sans text-[14px] font-bold leading-none justify-end items-center rounded-3xl ${
             actButtonSelected
               ? 'border-[1px]  bg-onepink border-primary text-primary'
               : 'bg-zeropink text-darkgray'
@@ -142,7 +145,11 @@ export default function UserMood() {
           buttonType="MOOD"
           isActive
           onClick={handleEmoButtonClick}
-          className={`mx-2 my-2  font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          imgSrc="/illustration/common/datemood/emotional.png"
+          imgSizeH={85}
+          imgSizeW={75}
+          imgClassName="h-[85px]"
+          className={`mx-2 my-2  font-sans text-[14px] font-bold leading-none justify-end items-center rounded-3xl ${
             emoButtonSelected
               ? 'border-[1px]  bg-onepink border-primary text-primary'
               : 'bg-zeropink text-darkgray'
@@ -153,7 +160,11 @@ export default function UserMood() {
           buttonType="MOOD"
           isActive
           onClick={handleNewButtonClick}
-          className={`mx-2 my-2  font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          imgSrc="/illustration/common/datemood/unusual.png"
+          imgSizeH={85}
+          imgSizeW={75}
+          imgClassName="h-[85px]"
+          className={`mx-2 my-2  font-sans text-[14px] font-bold leading-none justify-end items-center rounded-3xl ${
             newButtonSelected
               ? 'border-[1px] bg-onepink border-primary text-primary'
               : 'bg-zeropink text-darkgray'
@@ -164,7 +175,10 @@ export default function UserMood() {
           buttonType="MOOD"
           isActive
           onClick={handleFunButtonClick}
-          className={`mx-2 my-2 font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          imgSrc="/illustration/common/datemood/funny.png"
+          imgSizeH={85}
+          imgSizeW={75}
+          className={`mx-2 my-2 font-sans text-[14px] font-bold leading-none justify-end items-center rounded-3xl ${
             funButtonSelected
               ? 'border-[1px]  bg-onepink border-primary text-primary'
               : 'bg-zeropink text-darkgray'

--- a/src/app/_components/common/userinfo/UserMoodyAge.tsx
+++ b/src/app/_components/common/userinfo/UserMoodyAge.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/navigation'
 import { RANGE_BAR_AGE, MOODIE_AGE_PAGE } from '@/_constants'
 import { useRecoilState } from 'recoil'
-import { preferInfoState } from '@/_atom/userinfo'
+import { preferInfoState, userInfoState } from '@/_atom/userinfo'
 import { useState } from 'react'
 import RangeBar from '../RangeBar'
 import NormalButton from '../NormalButton'
@@ -18,6 +18,11 @@ export default function UserMoodyage({ pageNum }: UserMoodyageProps) {
   }
 
   const [userInfo, setUserInfo] = useRecoilState(preferInfoState)
+  const [myInfo, setMyInfo] = useRecoilState(userInfoState)
+  const moodyCharacter =
+    myInfo.gender === 'FEMALE'
+      ? '/illustration/female/age/partnerage.png'
+      : '/illustration/male/age/partnerpage.png'
 
   const [rangeValue, setRangeValue] = useState<number[]>(
     userInfo.preferYearMax !== 0 && userInfo.preferYearMin !== 0
@@ -50,8 +55,8 @@ export default function UserMoodyage({ pageNum }: UserMoodyageProps) {
           </div>
         </div>
       </div>
-      <div className="relative top-[0%] mt-[-50px] mb-[20px] left-[40%] ml-[-50px] w-[149px] h-[157px] text-darkgray flex justify-center items-center bg-lightgray">
-        이미지
+      <div className="relative top-[0%] mt-[-50px] mb-[20px] left-[40%] ml-[-50px] w-[149px] h-[157px]flex justify-center items-center">
+        <img src={moodyCharacter} alt="" width={149} height="auto" />
       </div>
       <div className="justify-items-center flex flex-col items-center">
         <RangeBar

--- a/src/app/_components/common/userinfo/UserMoodyAge.tsx
+++ b/src/app/_components/common/userinfo/UserMoodyAge.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation'
-import { RANGE_BAR_AGE, MY_AGE_PAGE } from '@/_constants'
+import { RANGE_BAR_AGE, MOODIE_AGE_PAGE } from '@/_constants'
 import { useRecoilState } from 'recoil'
 import { preferInfoState } from '@/_atom/userinfo'
 import { useState } from 'react'
@@ -43,10 +43,10 @@ export default function UserMoodyage({ pageNum }: UserMoodyageProps) {
       <div className="mt-[35px] mb-[88px]">
         <div>
           <div className="leading-normal text-darkgray font-bold text-xl font-sans">
-            {MY_AGE_PAGE.GREETINGS}
+            {MOODIE_AGE_PAGE.GREETINGS}
           </div>
           <div className="mt-[10px] text-secondary font-normal text-base font-sans">
-            <div>{MY_AGE_PAGE.WARNINGS}</div>
+            <div>{MOODIE_AGE_PAGE.WARNINGS}</div>
           </div>
         </div>
       </div>

--- a/src/app/_components/common/userinfo/UserMyage.tsx
+++ b/src/app/_components/common/userinfo/UserMyage.tsx
@@ -23,6 +23,12 @@ export default function UserMyage({ pageNum }: UserMyageProps) {
     userInfo.year !== 0 ? [userInfo.year] : [RANGE_BAR_AGE.MIN],
   )
 
+  const myCharacter =
+    userInfo.gender === 'FEMALE'
+      ? '/illustration/female/age/myage.png'
+      : '/illustration/male/age/myage.png'
+  console.log(myCharacter)
+
   const handleSingleChange = (newValues: number[]) => {
     setSingleValue(newValues)
   }
@@ -52,8 +58,8 @@ export default function UserMyage({ pageNum }: UserMyageProps) {
           </div>
         </div>
       </div>
-      <div className="relative top-[0%] mt-[-50px] mb-[20px] left-[40%] ml-[-50px] w-[149px] h-[157px] text-darkgray flex justify-center items-center bg-lightgray">
-        이미지
+      <div className="relative top-[0%] mt-[-60px] mb-[20px]  left-[40%] ml-[-50px] w-[149px] h-[157px] flex justify-center items-center">
+        <img src={myCharacter} alt="" width="149" height="atuo" />
       </div>
       <div className="justify-items-center flex flex-col items-center">
         <RangeBar

--- a/src/app/_components/common/userinfo/UserMyage.tsx
+++ b/src/app/_components/common/userinfo/UserMyage.tsx
@@ -27,7 +27,6 @@ export default function UserMyage({ pageNum }: UserMyageProps) {
     userInfo.gender === 'FEMALE'
       ? '/illustration/female/age/myage.png'
       : '/illustration/male/age/myage.png'
-  console.log(myCharacter)
 
   const handleSingleChange = (newValues: number[]) => {
     setSingleValue(newValues)

--- a/src/app/_components/common/userinfo/UserSameDept.tsx
+++ b/src/app/_components/common/userinfo/UserSameDept.tsx
@@ -60,7 +60,6 @@ export default function UserSameDept({ pageNum }: UserSameDeptProps) {
   useEffect(() => {
     setTrueButtonSelected(userInfo.preferDepartmentPossible === true)
     setFalseButtonSelected(userInfo.preferDepartmentPossible === false)
-    console.log(userInfo)
   }, [userInfo])
 
   return (
@@ -72,22 +71,22 @@ export default function UserSameDept({ pageNum }: UserSameDeptProps) {
       </div>
       <div>
         <SelectedButton
-          buttonText={MATCHING_DEPARTMENT_PAGE.SAME_DEPT}
+          buttonText={`${MATCHING_DEPARTMENT_PAGE.SAME_DEPT}\n${MATCHING_DEPARTMENT_PAGE.LIKE}`}
           buttonType="MAJOR"
           isActive
           onClick={handleTrueButtonClick}
-          className={`ml-[7px] font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          className={`ml-[7px] font-sans leading-none text-[14px] font-bold justify-end items-center rounded-3xl ${
             trueButtonSelected
               ? 'border-[1px] border-primary text-primary bg-onepink'
               : 'bg-zeropink '
           }`}
         />
         <SelectedButton
-          buttonText={MATCHING_DEPARTMENT_PAGE.DIFF_DEPT}
+          buttonText={`${MATCHING_DEPARTMENT_PAGE.DIFF_DEPT}\n${MATCHING_DEPARTMENT_PAGE.LIKE}`}
           buttonType="MAJOR"
           isActive
           onClick={handleFalseButtonClick}
-          className={`ml-[7px] font-sans text-[14px] font-normal justify-end items-center gap-[10px] rounded-3xl ${
+          className={`ml-[7px] font-sans leading-none text-[14px] font-bold justify-end items-center gap-[10px] rounded-3xl ${
             falseButtonSelected
               ? 'border-[1px] border-primary text-primary bg-onepink'
               : 'bg-zeropink '

--- a/src/app/_constants/info.ts
+++ b/src/app/_constants/info.ts
@@ -139,8 +139,9 @@ export const MOODIE_AGE_PAGE = {
 
 export const MATCHING_DEPARTMENT_PAGE = {
   GREETINGS: '어떤 것을 선호하시나요?',
-  SAME_DEPT: '같은 학과도 좋아요!',
-  DIFF_DEPT: '다른 학과가 좋아요!',
+  SAME_DEPT: '같은 학과도',
+  LIKE: '좋아요!',
+  DIFF_DEPT: '다른 학과가',
 } as const
 
 export const DATE_MOOD_PAGE = {


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

회원정보 입력 페이지들에 이미지를 추가하였습니다.
본인 나이 입력 페이지와 상대방 나이 입력 페이지는, 사용자의 성별을 확인 후, 상대방 성별 캐릭터가 나오도록 조건부 렌더링이 필요합니다.

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

Next.js를 사용하고 있기 때문에, 이미지 최적화가 필요합니다.

<br>

## 3. 관련 스크린샷을 첨부해주세요.

![image](https://github.com/Leets-Official/MoodMate-FE/assets/101498350/1701514f-21f3-4883-881b-bc93d7bc0142)
<br>
![image](https://github.com/Leets-Official/MoodMate-FE/assets/101498350/d600b7fe-a8c7-48da-ae00-f728f4eb6ed7)
본인 성별 : 여
<br>
![image](https://github.com/Leets-Official/MoodMate-FE/assets/101498350/204a149c-e53e-4ba4-83ef-9ddd50aded12)
본인인 성별 : 남
<br>
<br>
![image](https://github.com/Leets-Official/MoodMate-FE/assets/101498350/f6ec6f4d-0bdf-4d04-9e95-22154cdc33a4)
본인 성별 : 여
<br>
![image](https://github.com/Leets-Official/MoodMate-FE/assets/101498350/5074bc9f-13a5-4712-9bb4-22e17bdbfa93)
본인 성별 : 남
<br>
![image](https://github.com/Leets-Official/MoodMate-FE/assets/101498350/1bf04d14-e42d-46f4-83a4-229b15fac9f9)


<br>

## 4. 완료 사항

- [x] 성별 입력 페이지
- [x] 나의 나이 페이지
- [x] 무디 나이 페이지
- [x] 데이트 무드 페이지

<br>

## 5. 추가 사항

closed #111 
